### PR TITLE
A few fixes

### DIFF
--- a/src/Conditions.php
+++ b/src/Conditions.php
@@ -19,7 +19,7 @@ trait Conditions
      */
     public function whenHits(int $hits = 200000) : self
     {
-        return $this->when($hits > $this->opcache->getHits());
+        return $this->when($hits <= $this->opcache->getHits());
     }
 
     /**

--- a/src/GeneratesScript.php
+++ b/src/GeneratesScript.php
@@ -31,7 +31,7 @@ trait GeneratesScript
             '@opcache_memory_wasted' =>
                 number_format($opcache['memory_usage']['wasted_memory'] / 1024**2, 1, '.', ''),
             '@opcache_files' => $opcache['opcache_statistics']['num_cached_scripts'],
-            '@opcache_hit_rate' => $opcache['opcache_statistics']['opcache_hit_rate'] * 100,
+            '@opcache_hit_rate' => number_format($opcache['opcache_statistics']['opcache_hit_rate'], 2, '.', ''),
             '@opcache_misses' => $opcache['opcache_statistics']['misses'],
         ];
     }


### PR DESCRIPTION
- whenHits condition now evaluates true when current hits (reported by opcache) is under given $hits, opposed to the documentation which should be true when it reaches that number
- opcache_hit_rate is already reported as percent, no need to multiply by 100 and also format it, to strip too many decimals