### PR TITLE
Revert "A few fixes"

### DIFF
--- a/src/Conditions.php
+++ b/src/Conditions.php
@@ -19,7 +19,7 @@ trait Conditions
      */
     public function whenHits(int $hits = 200000) : self
     {
-        return $this->when($hits <= $this->opcache->getHits());
+        return $this->when($hits > $this->opcache->getHits());
     }
 
     /**

--- a/src/GeneratesScript.php
+++ b/src/GeneratesScript.php
@@ -31,7 +31,7 @@ trait GeneratesScript
             '@opcache_memory_wasted' =>
                 number_format($opcache['memory_usage']['wasted_memory'] / 1024**2, 1, '.', ''),
             '@opcache_files' => $opcache['opcache_statistics']['num_cached_scripts'],
-            '@opcache_hit_rate' => number_format($opcache['opcache_statistics']['opcache_hit_rate'], 2, '.', ''),
+            '@opcache_hit_rate' => $opcache['opcache_statistics']['opcache_hit_rate'] * 100,
             '@opcache_misses' => $opcache['opcache_statistics']['misses'],
         ];
     }


### PR DESCRIPTION
Reverts DarkGhostHunter/Preloader#13

Had to revert the where fix for a simple reason: `whereHits` should evaluate to false if the hits haven't reached a given threshold. Check the reviews.