### PR TITLE
Fatal exceptions are not caught or logged during preload

### DIFF
--- a/src/preload.php.stub
+++ b/src/preload.php.stub
@@ -34,6 +34,10 @@
 
 register_shutdown_function(function (): void {
     $error = error_get_last();
+    if (!$error) {
+        return;
+    }
+    
     echo 'Message: ' . $error['message'] . \PHP_EOL;
     echo 'File: ' . $error['file'] . \PHP_EOL;
 });

--- a/src/preload.php.stub
+++ b/src/preload.php.stub
@@ -32,6 +32,12 @@
  * @see https://github.com/darkghosthunter/preloader
  */
 
+register_shutdown_function(function (): void {
+    $error = error_get_last();
+    echo 'Message: ' . $error['message'] . \PHP_EOL;
+    echo 'File: ' . $error['file'] . \PHP_EOL;
+});
+
 require_once '@autoload';
 
 $files = [@list];


### PR DESCRIPTION
By registering a shutdown function, we can catch fatal exceptions and print them in the same way we'd print other errors.  I thought about sharing the `echo` logic between the try/catch and the shutdown function, however, decided against potentially polluting the global scope.