### PR TITLE
[deps] Allow Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.4||^8.0",
         "ext-json": "*",
-        "symfony/finder": "^4.3||^5.0.5"
+        "symfony/finder": "^4.3||^5.0.5||^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3"


### PR DESCRIPTION
Hi :slightly_smiling_face: , 

we're in a process of upgrading to Symfony 6 and composer warned us about incompatibility with this packages.
I'm checking if there is anything blocking to use allow this package on Symfony 6. 

Btw, I've noticed you're using scrutinizer. Would you be interested in another PR with open-sourced static analysis tool PHPStan that handles similar code quality checks?