### PR TITLE
allow to use new versions of symfony/finder v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.4||^8.0",
         "ext-json": "*",
-        "symfony/finder": "^4.3||^5.0.5"
+        "symfony/finder": "^4.3||^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3"


### PR DESCRIPTION
This PR allows to use new versions of package `symfony/finder` v5. The change has been used in a production environment without causing any issue.